### PR TITLE
Simplify `Generic` parser generation.

### DIFF
--- a/src/Control/Biegunka.hs
+++ b/src/Control/Biegunka.hs
@@ -18,7 +18,7 @@ module Control.Biegunka
     -- * Auxiliary
   , into
     -- * Commandline options parser autogeneration
-  , runner_, runnerOf, Environments(..), Generic, Proxy(Proxy)
+  , runner_, runnerOf, Environments(..), Generic
     -- * Quasiquoters
   , multiline, sh, shell
     -- * Settings
@@ -29,7 +29,6 @@ module Control.Biegunka
   , pass
   ) where
 
-import Data.Proxy (Proxy(Proxy))
 import GHC.Generics (Generic)
 import System.Directory.Layout (username, uid)
 

--- a/src/Control/Biegunka/Options.hs
+++ b/src/Control/Biegunka/Options.hs
@@ -60,7 +60,7 @@ parser p = info (helper <*> go) fullDesc
     , flag' safe  (long "run"      <> help "Run script")
     , flag' check (long "problems" <> help "Show problems")
     , flag' run   (long "force"    <> help "Run script without a confirmation")
-    , flag' all   (long "all"      <> help "A combination of --changes, --run, and --problems")
+    , flag' all   (long "all"      <> help "Show changes, run the script, and show problems")
     , pure all
     ]
 
@@ -109,7 +109,7 @@ instance (G.Constructor c, GEnvironment f) => GEnvironment (G.C1 c f) where
 
 -- | Constructors without arguments are flags.
 instance GEnvironment G.U1 where
-  genv Option { optionName } = maybe empty (flag' G.U1 . long) optionName
+  genv Option { optionName } = G.U1 <$ maybe empty (flag' () . long) optionName
 
 -- | Constants are options.
 instance Read c => GEnvironment (G.K1 i c) where

--- a/test/spec/Control/Biegunka/OptionsSpec.hs
+++ b/test/spec/Control/Biegunka/OptionsSpec.hs
@@ -2,7 +2,6 @@
 module Control.Biegunka.OptionsSpec (spec) where
 
 import Control.Lens
-import Data.Proxy (Proxy(Proxy))
 import Data.Foldable (for_)
 import GHC.Generics
 import Options.Applicative
@@ -13,7 +12,7 @@ import Control.Biegunka.Options
 
 
 data Type = Foo | QuxQuux
-    deriving (Show, Eq, Bounded, Enum, Generic)
+    deriving (Show, Eq, Generic)
 
 instance Environments Type
 
@@ -22,21 +21,21 @@ spec =
   describe "parser" $ do
     context "when asked for a single-word environment" $
       it "returns the corresponding constructor" $
-        parse Proxy ["--foo"] `shouldHave` _Just._1.only Foo
+        parse ["--foo"] `shouldHave` _Just._1.only Foo
 
     context "when asked for a multi-word environment" $
       it "returns the corresponding constructor" $
-        parse Proxy ["--qux-quux"] `shouldHave` _Just._1.only QuxQuux
+        parse ["--qux-quux"] `shouldHave` _Just._1.only QuxQuux
 
     describe "interpreters" $
       for_ ["--diff", "--run", "--problems", "--force", "--all"] $ \i ->
         it ("parser includes the ‘" ++ i ++ "’ interpreter") $
-          parse Proxy [i, "--foo"] `shouldHave` _Just._1.only Foo
+          parse [i, "--foo"] `shouldHave` _Just._1.only Foo
 
     describe "modes" $
       for_ ["--online", "--offline"] $ \m ->
         it ("parser includes the ‘" ++ m ++ "’ mode") $
-          parse Proxy [m, "--foo"] `shouldHave` _Just._1.only Foo
+          parse [m, "--foo"] `shouldHave` _Just._1.only Foo
 
-parse :: Environments a => proxy a -> [String] -> Maybe (a, Runner b)
-parse proxy = getParseResult . execParserPure (prefs idm) (parser (fromEnvironments proxy))
+parse :: Environments a => [String] -> Maybe (a, Runner b)
+parse = getParseResult . execParserPure (prefs idm) (parser environments)

--- a/test/spec/Control/Biegunka/OptionsSpec.hs
+++ b/test/spec/Control/Biegunka/OptionsSpec.hs
@@ -1,41 +1,41 @@
 {-# LANGUAGE DeriveGeneric #-}
 module Control.Biegunka.OptionsSpec (spec) where
 
-import Control.Lens
 import Data.Foldable (for_)
 import GHC.Generics
 import Options.Applicative
 import Test.Hspec.Lens
-import Text.Show.Functions ()
+import Text.Printf (printf)
 
 import Control.Biegunka.Options
 
 
-data Type = Foo | QuxQuux
+data Foo = Bar | QuxQuux | Xyzzy Int
     deriving (Show, Eq, Generic)
 
-instance Environments Type
+instance Environments Foo
 
 spec :: Spec
 spec =
   describe "parser" $ do
-    context "when asked for a single-word environment" $
-      it "returns the corresponding constructor" $
-        parse ["--foo"] `shouldHave` _Just._1.only Foo
+    it "single-word environments are selected by lowercase flags" $
+      parse ["--bar"] `shouldBe` Just Bar
 
-    context "when asked for a multi-word environment" $
-      it "returns the corresponding constructor" $
-        parse ["--qux-quux"] `shouldHave` _Just._1.only QuxQuux
+    it "multi-word environments are selected by lowercase lisp-case flags" $
+      parse ["--qux-quux"] `shouldBe` Just QuxQuux
+
+    it "environments taking an argument are selected by lowercase options" $
+      parse ["--xyzzy", "7"] `shouldBe` Just (Xyzzy 7)
 
     describe "interpreters" $
       for_ ["--diff", "--run", "--problems", "--force", "--all"] $ \i ->
-        it ("parser includes the ‘" ++ i ++ "’ interpreter") $
-          parse [i, "--foo"] `shouldHave` _Just._1.only Foo
+        it (printf "parser includes the ‘%s’ interpreter" i) $
+          parse [i, "--bar"] `shouldBe` Just Bar
 
     describe "modes" $
       for_ ["--online", "--offline"] $ \m ->
-        it ("parser includes the ‘" ++ m ++ "’ mode") $
-          parse [m, "--foo"] `shouldHave` _Just._1.only Foo
+        it (printf "parser includes the ‘%s’ mode" m) $
+          parse [m, "--bar"] `shouldBe` Just Bar
 
-parse :: Environments a => [String] -> Maybe (a, Runner b)
-parse = getParseResult . execParserPure (prefs idm) (parser environments)
+parse :: Environments a => [String] -> Maybe a
+parse = fmap fst . getParseResult . execParserPure (prefs idm) (parser environments)


### PR DESCRIPTION
  - Eliminate the proxy argument of `runnerOf`.

  - Stop requiring `Bounded` and `Enum` from generic `Environments`
    instances.